### PR TITLE
Update version to match repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Browser & Mobile detection package for Laravel 4-5.",
     "keywords": ["laravel", "user-agent", "browser", "mobile", "tablet", "user agent", "mobile", "tablet", "greenball", "hisorange"],
     "license": "MIT",
-    "version": "2.0.0",
+    "version": "2.0.1",
 
     "authors": [
         {


### PR DESCRIPTION
This is in reference to issue #31 because it wasn't working unless using `dev-master`. Not 100% sure if this is how composer figures out what version things are on, but I'm going to assume this is how it's done.
